### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Sort/Naturally.pm6
+++ b/lib/Sort/Naturally.pm6
@@ -1,4 +1,4 @@
-module Sort::Naturally:ver<0.2.0>;
+unit module Sort::Naturally:ver<0.2.0>;
 use v6;
 
 # Routines to do the transformation for sorting


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
