### PR TITLE
Fix meta

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-    "perl"        : "v6"
+    "perl"        : "v6.*",
     "name"        : "Sort::Naturally",
     "version"     : "0.2.0",
     "description" : "Provides several routines to ease natural sorting.",


### PR DESCRIPTION
Fixes two issues:
1) There was a missing comma after `"perl": "v6"`, which was causing a JSON parsing error
2) I don't think a mere `"v6"` for perl version is sufficient, considering the Christmas release will be `v6.c`, yet `v6` seems to be a version "after" v6.c:

```
<ZoffixW> m: say v6 before v6.c
<camelia> rakudo-moar ce6467: OUTPUT«False␤»
```
